### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "klasa": "github:dirigeants/klasa",
     "discord.js": "github:discordjs/discord.js"
   },
-  "devDependencies": {
+  "dependencies": {
     "ytdl-core": "^0.21.1"
   },
   "repository": "https://github.com/Tylertron1998/klasa-music-plugin"


### PR DESCRIPTION
This PR should allow users to automatically have the ytdl-core installed when doing `npm i`

 ```js
[2019-01-06 12:47:02] Failed to load file 'node_modules/klasa-music-plugin/src/lib/drivers/Youtube.js'. Error:
[2019-01-06 12:47:02] Error: Cannot find module 'ytdl-core'
[2019-01-06 12:47:02]     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
[2019-01-06 12:47:02]     at Function.Module._load (internal/modules/cjs/loader.js:507:25)
[2019-01-06 12:47:02]     at Module.require (internal/modules/cjs/loader.js:637:17)
[2019-01-06 12:47:02]     at require (internal/modules/cjs/helpers.js:20:18)```